### PR TITLE
给WKWebview设置cookie，长按图片弹出UIActionSheet保存图片

### DIFF
--- a/Classes/IMYWebView.h
+++ b/Classes/IMYWebView.h
@@ -18,6 +18,7 @@
 - (void)webViewDidFinishLoad:(IMYWebView*)webView;
 - (void)webView:(IMYWebView*)webView didFailLoadWithError:(NSError*)error;
 - (BOOL)webView:(IMYWebView*)webView shouldStartLoadWithRequest:(NSURLRequest*)request navigationType:(UIWebViewNavigationType)navigationType;
+- (void)webView:(IMYWebView*)webView longPressSaveImageUrl:(NSURL *)imageUrl;
 
 @end
 
@@ -26,6 +27,8 @@
 
 ///使用UIWebView
 - (instancetype)initWithFrame:(CGRect)frame usingUIWebView:(BOOL)usingUIWebView;
+///给WKWebView添加cookie：@"document.cookie = 'token=xxxxxxxxxxx';"
+- (instancetype)initWithFrame:(CGRect)frame usingUIWebView:(BOOL)usingUIWebView cookieString:(NSString *)cookieString;
 
 ///会转接 WKUIDelegate，WKNavigationDelegate 内部未实现的回调。
 @property (weak, nonatomic) id<IMYWebViewDelegate> delegate;
@@ -61,6 +64,8 @@
 @property (nonatomic, readonly, getter=isLoading) BOOL loading;
 @property (nonatomic, readonly) BOOL canGoBack;
 @property (nonatomic, readonly) BOOL canGoForward;
+
+@property (nonatomic, assign) BOOL canLongPressSaveImage; //长按是否保存图片
 
 - (id)goBack;
 - (id)goForward;

--- a/Classes/IMYWebView.m
+++ b/Classes/IMYWebView.m
@@ -13,14 +13,15 @@
 #import <WebKit/WebKit.h>
 #import <dlfcn.h>
 
-@interface IMYWebView () <UIWebViewDelegate, WKNavigationDelegate, WKUIDelegate, IMY_NJKWebViewProgressDelegate>
+@interface IMYWebView () <UIWebViewDelegate, WKNavigationDelegate, WKUIDelegate, IMY_NJKWebViewProgressDelegate,UIActionSheetDelegate,UIGestureRecognizerDelegate>
 
 @property (nonatomic, assign) double estimatedProgress;
 @property (nonatomic, strong) NSURLRequest* originRequest;
 @property (nonatomic, strong) NSURLRequest* currentRequest;
 
 @property (nonatomic, copy) NSString* title;
-
+@property (nonatomic, strong) NSURL *saveImageURL;
+@property (nonatomic, copy) NSString *cookieString;
 @property (nonatomic, strong) IMY_NJKWebViewProgress* njkWebViewProgress;
 @end
 
@@ -48,9 +49,14 @@
 }
 - (instancetype)initWithFrame:(CGRect)frame usingUIWebView:(BOOL)usingUIWebView
 {
+    return [self initWithFrame:frame usingUIWebView:usingUIWebView cookieString:nil];
+}
+- (instancetype)initWithFrame:(CGRect)frame usingUIWebView:(BOOL)usingUIWebView cookieString:(NSString *)cookieString{
     self = [super initWithFrame:frame];
-    if (self) {
+    if (self)
+    {
         _usingUIWebView = usingUIWebView;
+        _cookieString = cookieString;
         [self _initMyself];
     }
     return self;
@@ -91,8 +97,15 @@
 }
 - (void)initWKWebView
 {
+    WKUserContentController* userContentController = [NSClassFromString(@"WKUserContentController") new];
+    WKUserScript * cookieScript = [[NSClassFromString(@"WKUserScript") alloc]
+                                   initWithSource: _cookieString
+                                   injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:NO];
+    [userContentController addUserScript:cookieScript];
+    
+    
     WKWebViewConfiguration* configuration = [[NSClassFromString(@"WKWebViewConfiguration") alloc] init];
-    configuration.userContentController = [NSClassFromString(@"WKUserContentController") new];
+    configuration.userContentController = userContentController;
     
     WKPreferences* preferences = [NSClassFromString(@"WKPreferences") new];
     preferences.javaScriptCanOpenWindowsAutomatically = YES;
@@ -249,6 +262,88 @@
         resultBOOL = [self.delegate webView:self shouldStartLoadWithRequest:request navigationType:navigationType];
     }
     return resultBOOL;
+}
+
+#pragma mark - 处理长按弹出图片
+
+- (void)setCanLongPressSaveImage:(BOOL)canLongPressSaveImage{
+    
+    _canLongPressSaveImage = canLongPressSaveImage;
+    if (_canLongPressSaveImage) {
+        UILongPressGestureRecognizer *longPressGessture = [[UILongPressGestureRecognizer alloc]initWithTarget:self action:@selector(longPress:)];
+        longPressGessture.delegate = self;
+        longPressGessture.cancelsTouchesInView = NO;
+        [self addGestureRecognizer:longPressGessture];
+    }
+}
+
+- (void)longPress:(UILongPressGestureRecognizer *)longGesture
+{
+    if (longGesture.state == UIGestureRecognizerStateBegan) {
+        CGPoint recivePoint = [longGesture locationInView:self];
+        recivePoint = [self.realWebView convertPoint:recivePoint fromView:self];
+        
+        CGPoint webViewOffset = [(UIScrollView *)[self.realWebView valueForKey:@"scrollView"] contentOffset];
+        
+        recivePoint.x = recivePoint.x + webViewOffset.x;
+        recivePoint.y = recivePoint.y + webViewOffset.y;
+        
+        [self checkImageAtPoint:recivePoint];
+    }
+}
+
+- (void)checkImageAtPoint:(CGPoint)point
+{
+    //首先得到长按的位置在webView中是什么节点,如果节点处有img,然后提取出url.
+    //注入js
+    [self stringByEvaluatingJavaScriptFromString:@"     \
+     function MyAppGetHTMLElementsAtPoint(x,y) {     \
+     var tags = \",\";                           \
+     var e = document.elementFromPoint(x,y);     \
+     while (e) {                                 \
+     if (e.tagName) {                        \
+     tags += e.tagName + ',';            \
+     }                                       \
+     e = e.parentNode;                           \
+     }                                           \
+     return tags;                                \
+     }"
+     ];
+    
+    //执行js
+    NSString *tags = [self stringByEvaluatingJavaScriptFromString:
+                      [NSString stringWithFormat:@"MyAppGetHTMLElementsAtPoint(%f,%f);",point.x,point.y]];
+    
+    if ([tags rangeOfString:@",IMG,"].location != NSNotFound) {
+        UIActionSheet *sheet = [[UIActionSheet alloc] initWithTitle:nil
+                                                           delegate:self cancelButtonTitle:@"取消"
+                                             destructiveButtonTitle:nil otherButtonTitles:nil];
+        NSString *str = [NSString stringWithFormat:@"document.elementFromPoint(%f, %f).src", point.x, point.y];
+        NSString *imgString= [self stringByEvaluatingJavaScriptFromString:str];
+        self.saveImageURL = [NSURL URLWithString:imgString];
+        [sheet addButtonWithTitle:@"保存图片"];
+        [sheet showInView:self];
+    }
+}
+
+- (void)actionSheet:(UIActionSheet *)actionSheet clickedButtonAtIndex:(NSInteger)buttonIndex
+{
+    if (buttonIndex == 1) {
+        if ([self.delegate respondsToSelector:@selector(webView:longPressSaveImageUrl:)]) {
+            [self.delegate webView:self longPressSaveImageUrl:self.saveImageURL];
+        }
+    }
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+{
+    
+    return NO;
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+{
+    return YES;
 }
 
 #pragma mark - 基础方法

--- a/IMYWebView/FirstViewController.m
+++ b/IMYWebView/FirstViewController.m
@@ -27,7 +27,8 @@
 {
     self.view.backgroundColor = [UIColor whiteColor];
     [super viewDidLoad];
-    self.webView = [[IMYWebView alloc] initWithFrame:self.view.bounds];
+    self.webView = [[IMYWebView alloc] initWithFrame:self.view.bounds usingUIWebView:NO cookieString:@"document.cookie = 'token=xxxxxxxxxxx';"];
+    self.webView.canLongPressSaveImage = YES;
     [self.view addSubview:_webView];
     
     if(_webView.usingUIWebView)

--- a/IMYWebView/SecondViewController.m
+++ b/IMYWebView/SecondViewController.m
@@ -27,6 +27,7 @@
     [super viewDidLoad];
     
     self.webView = [[IMYWebView alloc] initWithFrame:self.view.bounds usingUIWebView:YES];
+    self.webView.canLongPressSaveImage = YES;
     [self.view addSubview:_webView];
     
     if(_webView.usingUIWebView)


### PR DESCRIPTION
现在我要给wkwebview设置cookie，如代码中在创建WKWebView的时候是没问题的
`WKUserContentController* userContentController = [NSClassFromString(@"WKUserContentController") new];
    WKUserScript * cookieScript = [[NSClassFromString(@"WKUserScript") alloc]
                                   initWithSource: _cookieString
                                   injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:NO];
    // again, use stringWithFormat: in the above line to inject your values programmatically
    [userContentController addUserScript:cookieScript];
`
本来我想在webViewDidFinishLoad的时候执行'[webView evaluateJavaScript:[self getWKWebViewCookies] completionHandler:nil];'来设置cookie，但这时候设置晚了点，h5没拿到cookie，要重新刷新一遍才行。 
那是不是在创建的时候设置比较好呢？

长按图片弹出UIActionSheet保存图片这个需求是在项目中用到的，可以在自己给它加上长按手势，我现在把这个功能写到了这个类里面，不知道合不合理？
